### PR TITLE
fix: upgraded PricesHelper to allow upgradeable oracle address [WEB-366]

### DIFF
--- a/contracts/Utilities/Helper/Helpers/PricesHelper.sol
+++ b/contracts/Utilities/Helper/Helpers/PricesHelper.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.2;
 
+import "../../Manageable.sol";
+
 interface IOracle {
     function getPriceUsdcRecommended(address tokenAddress)
         external
@@ -9,17 +11,17 @@ interface IOracle {
         returns (uint256);
 }
 
-contract PricesHelper {
-    IOracle public oracle;
+contract PricesHelper is Manageable {
+    address public oracleAddress;
 
     struct TokenPrice {
         address tokenId;
         uint256 priceUsdc;
     }
 
-    constructor(address oracleAddress) {
-        require(oracleAddress != address(0), "Missing oracle address");
-        oracle = IOracle(oracleAddress);
+    constructor(address _oracleAddress, address _managementListAddress) Manageable(_managementListAddress) {
+        require(_oracleAddress != address(0), "Missing oracle address");
+        oracleAddress = _oracleAddress;
     }
 
     function tokensPrices(address[] memory tokensAddresses)
@@ -37,9 +39,15 @@ contract PricesHelper {
             address tokenAddress = tokensAddresses[tokenIdx];
             _tokensPrices[tokenIdx] = TokenPrice({
                 tokenId: tokenAddress,
-                priceUsdc: oracle.getPriceUsdcRecommended(tokenAddress)
+                priceUsdc: IOracle(oracleAddress).getPriceUsdcRecommended(tokenAddress)
             });
         }
         return _tokensPrices;
     }
+    
+    function updateOracleAddress(address _oracleAddress) external onlyManagers {
+        oracleAddress = _oracleAddress;
+    }
+
 }
+

--- a/contracts/Utilities/Helper/Helpers/PricesHelper.sol
+++ b/contracts/Utilities/Helper/Helpers/PricesHelper.sol
@@ -50,4 +50,3 @@ contract PricesHelper is Manageable {
     }
 
 }
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,8 +61,8 @@ def introspection(Introspection, management):
 
 
 @pytest.fixture
-def pricesHelper(PricesHelper, management, managementList, oracle):
-    return PricesHelper.deploy(oracle, {"from": management})
+def pricesHelper(PricesHelper, management, managementList, oracle, ):
+    return PricesHelper.deploy(oracle, managementList, {"from": management})
 
 
 @pytest.fixture
@@ -403,3 +403,4 @@ def chad(accounts):
 @pytest.fixture
 def rando(accounts):
     yield Account.create().address
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def introspection(Introspection, management):
 
 
 @pytest.fixture
-def pricesHelper(PricesHelper, management, managementList, oracle, ):
+def pricesHelper(PricesHelper, management, managementList, oracle):
     return PricesHelper.deploy(oracle, managementList, {"from": management})
 
 
@@ -403,4 +403,3 @@ def chad(accounts):
 @pytest.fixture
 def rando(accounts):
     yield Account.create().address
-

--- a/tests/oracle/test_oracle.py
+++ b/tests/oracle/test_oracle.py
@@ -203,4 +203,3 @@ def test_get_lp_token_total_liquidity_usdc(oracleProxySushiswap):
         uniswapLpTokenAddress
     )
     assert totalLiquidity > 0
-    

--- a/tests/oracle/test_oracle.py
+++ b/tests/oracle/test_oracle.py
@@ -1,7 +1,7 @@
 import pytest
 import brownie
 
-from brownie import Contract, ZERO_ADDRESS
+from brownie import Contract, ZERO_ADDRESS, chain
 
 # Oracle deployment options
 uniswapRouterAddress = "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"
@@ -39,6 +39,16 @@ def oracleProxyCurve(oracle, CalculationsCurve):
 
 
 # General
+def test_update_prices_helper_oracle_address(pricesHelper, management):
+    chain.snapshot()
+    oracleAddress = pricesHelper.oracleAddress()
+    newOracleAddress = "0x83d95e0D5f402511dB06817Aff3f9eA88224B030"
+    oldOracleAddress = "0x6951b5Bd815043E3F842c1b026b0Fa888Cc2DD85"
+    assert oracleAddress == oldOracleAddress
+    pricesHelper.updateOracleAddress(newOracleAddress, {"from": management})
+    assert pricesHelper.oracleAddress() == newOracleAddress
+    chain.revert()
+
 def test_add_and_remove_token_alias(oracle, management):
     assert oracle.tokenAliases(ethAddress) != ZERO_ADDRESS
     oracle.removeTokenAlias(ethAddress, {"from": management})
@@ -168,6 +178,7 @@ def test_get_price_from_router(oracleProxySushiswap):
     # wethPriceAfterFees = oracleProxySushiswap.getPriceFromRouter(
     #     wethAddress, usdcAddress
     # )
+    print(wethPrice)
     assert ethPrice == wethPrice
     # assert wethPrice > wethPriceAfterFees
     usdcPriceInEth = oracleProxySushiswap.getPriceFromRouter(usdcAddress, ethAddress)
@@ -193,3 +204,4 @@ def test_get_lp_token_total_liquidity_usdc(oracleProxySushiswap):
         uniswapLpTokenAddress
     )
     assert totalLiquidity > 0
+

--- a/tests/oracle/test_oracle.py
+++ b/tests/oracle/test_oracle.py
@@ -178,7 +178,6 @@ def test_get_price_from_router(oracleProxySushiswap):
     # wethPriceAfterFees = oracleProxySushiswap.getPriceFromRouter(
     #     wethAddress, usdcAddress
     # )
-    print(wethPrice)
     assert ethPrice == wethPrice
     # assert wethPrice > wethPriceAfterFees
     usdcPriceInEth = oracleProxySushiswap.getPriceFromRouter(usdcAddress, ethAddress)
@@ -204,3 +203,4 @@ def test_get_lp_token_total_liquidity_usdc(oracleProxySushiswap):
         uniswapLpTokenAddress
     )
     assert totalLiquidity > 0
+    

--- a/tests/oracle/test_oracle.py
+++ b/tests/oracle/test_oracle.py
@@ -204,4 +204,3 @@ def test_get_lp_token_total_liquidity_usdc(oracleProxySushiswap):
         uniswapLpTokenAddress
     )
     assert totalLiquidity > 0
-


### PR DESCRIPTION
The PricesHelper contract (0x5D63a8584D91EBc5033D022AfD6c5A7c7FDDc99B) was using the old oracle (0xd3ca98d986be88b72ff95fc2ec976a5e6339150d) which wasn't upgradeable. 

We should redeploy a new PricesHelper that uses the new oracle (0x83d95e0D5f402511dB06817Aff3f9eA88224B030) and also make it possible to updrade the oracle address

Deployed at https://etherscan.io/address/0x8ab8309ccb1beeb21a7d1e9f765b7b3595885e2f