### PR TITLE
fix: added manual check for eth address when using isLpToken 

### DIFF
--- a/contracts/Oracle/Calculations/Sushiswap.sol
+++ b/contracts/Oracle/Calculations/Sushiswap.sol
@@ -141,6 +141,9 @@ contract CalculationsSushiswap {
     }
 
     function isLpToken(address tokenAddress) public view returns (bool) {
+        if (tokenAddress == ethAddress) {
+            return false;
+        }
         Pair lpToken = Pair(tokenAddress);
         try lpToken.factory() {
             return true;

--- a/tests/oracle/test_oracle.py
+++ b/tests/oracle/test_oracle.py
@@ -171,6 +171,9 @@ def test_is_lp_token(oracleProxySushiswap):
     tokenIsLp = oracleProxySushiswap.isLpToken(uniswapLpTokenAddress)
     assert tokenIsLp
 
+def test_eth_is_not_lp_token(oracleProxySushiswap):
+    is_lp_token = oracleProxySushiswap.isLpToken(ethAddress)
+    assert is_lp_token == False
 
 def test_get_price_from_router(oracleProxySushiswap):
     ethPrice = oracleProxySushiswap.getPriceFromRouter(ethAddress, usdcAddress)
@@ -183,7 +186,6 @@ def test_get_price_from_router(oracleProxySushiswap):
     usdcPriceInEth = oracleProxySushiswap.getPriceFromRouter(usdcAddress, ethAddress)
     usdcPriceInWeth = oracleProxySushiswap.getPriceFromRouter(usdcAddress, wethAddress)
     assert usdcPriceInEth == usdcPriceInWeth
-
 
 def test_get_router_for_lp_token(oracleProxySushiswap):
     derivedRouterAddress = oracleProxySushiswap.getRouterForLpToken(


### PR DESCRIPTION
Passing `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` into `isLpToken` causes a revert because it's not a valid contract. 

This causes failures in calculating some eth related token prices, mostly when using the oracle to calculate curve token prices, because the underlying tokens of some curve pools contains 0xEeee...