### PR TITLE
[WEB-1283-35] feat: add chainlink registry calculations

### DIFF
--- a/contracts/Oracle/Calculations/ChainlinkRegistry.sol
+++ b/contracts/Oracle/Calculations/ChainlinkRegistry.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+
+import "../../Utilities/Ownable.sol";
+
+interface ChainlinkFeed {
+    function latestAnswer() external view returns (int256);
+}
+
+contract CalculationsChainlinkRegistry is Ownable {
+
+    struct TokenFeedData {
+        address token;
+        address feed;
+    }
+
+    mapping(address => address) public tokenToFeed;
+
+    function setTokenFeed(address tokenAddress, address feed) external onlyOwner {
+        tokenToFeed[tokenAddress] = feed;
+    }
+
+    function setTokenFeeds(TokenFeedData[] memory tokenFeedData) external onlyOwner {
+        for (uint256 idx; idx < tokenFeedData.length; idx++) {
+            TokenFeedData memory tokenFeedData = tokenFeedData[idx];
+            tokenToFeed[tokenFeedData.token] = tokenFeedData.feed;
+        }
+    }
+
+    function getPriceUsdc(address tokenAddress) public view returns (uint256) {
+        address feed = tokenToFeed[tokenAddress];
+        require(feed != address(0));
+        return uint256(ChainlinkFeed(feed).latestAnswer()) / 10 ** 2;
+    }
+}

--- a/contracts/Oracle/Calculations/ChainlinkRegistry.sol
+++ b/contracts/Oracle/Calculations/ChainlinkRegistry.sol
@@ -22,8 +22,8 @@ contract CalculationsChainlinkRegistry is Ownable {
 
     function setTokenFeeds(TokenFeedData[] memory tokenFeedData) external onlyOwner {
         for (uint256 idx; idx < tokenFeedData.length; idx++) {
-            TokenFeedData memory tokenFeedData = tokenFeedData[idx];
-            tokenToFeed[tokenFeedData.token] = tokenFeedData.feed;
+            TokenFeedData memory tokenFeedDatum = tokenFeedData[idx];
+            tokenToFeed[tokenFeedDatum.token] = tokenFeedDatum.feed;
         }
     }
 

--- a/tests/oracle/test_chainlink_registry_calcs.py
+++ b/tests/oracle/test_chainlink_registry_calcs.py
@@ -1,0 +1,37 @@
+import brownie
+import pytest
+from brownie import ZERO_ADDRESS, chain
+
+YFI = "0x82e3A8F066a6989666b031d916c43672085b1582"
+YFI_USD_FEED = "0x745Ab5b69E01E2BE1104Ca84937Bb71f96f5fB21"
+
+WETH = "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
+WETH_USD_FEED = "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612"
+
+@pytest.fixture
+def calculations_chainlink_registry(CalculationsChainlinkRegistry, management):
+    return CalculationsChainlinkRegistry.deploy({"from": management})
+
+def test_adding_feed(calculations_chainlink_registry):
+    chain.snapshot()
+    with brownie.reverts():
+        calculations_chainlink_registry.getPriceUsdc(YFI)
+
+    calculations_chainlink_registry.setTokenFeed(YFI, YFI_USD_FEED)
+
+    assert calculations_chainlink_registry.getPriceUsdc(YFI) > 0
+    chain.revert()
+
+def test_adding_multiple_feeds(calculations_chainlink_registry, management):
+    chain.snapshot()
+    with brownie.reverts():
+        calculations_chainlink_registry.getPriceUsdc(YFI)
+
+    with brownie.reverts():
+        calculations_chainlink_registry.getPriceUsdc(WETH)
+
+    calculations_chainlink_registry.setTokenFeeds([(YFI, YFI_USD_FEED), (WETH, WETH_USD_FEED)], {"from": management})
+
+    assert calculations_chainlink_registry.getPriceUsdc(YFI) > 0
+    assert calculations_chainlink_registry.getPriceUsdc(WETH) > 0
+    chain.revert()


### PR DESCRIPTION
Happy for any feedback about if this needs re-architecting. I thought about adding this functionality into the existing [Chainlink Calculations contract ](https://github.com/yearn/yearn-lens/blob/master/contracts/Oracle/Calculations/Chainlink.sol) but decided against it to avoid mixing plain addresses and ens, since ens is not compatible with chains other than mainnet (I'm going to be using this for Arbitrum)