### PR TITLE
Refactor/prices helper use provider

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,8 +102,11 @@ def strings(String, management):
 
 
 @pytest.fixture
-def pricesHelper(PricesHelper, management, oracle):
-    return PricesHelper.deploy(oracle, {"from": management})
+def pricesHelper(PricesHelper, management):
+    return PricesHelper.deploy(
+            yearnAddressesProviderAddress,
+            {"from": management}
+            )
 
 
 @pytest.fixture

--- a/tests/helpers/test_helper_prices.py
+++ b/tests/helpers/test_helper_prices.py
@@ -42,9 +42,9 @@ def test_tokens_prices_normalized_usdc(pricesHelper):
     use 18-6 = 12 decimals for erc20 testing
     """
     token_prices = pricesHelper.tokensPricesNormalizedUsdc(
-        [(usdcAddress, 1), (crvAddress, 1e12)]
+        [(yfiAddress, 1e12), (crvAddress, 1e12)]
     )
-    assert token_prices[0][0] == usdcAddress
+    assert token_prices[0][0] == yfiAddress
     assert token_prices[0][1] > 0
     assert token_prices[1][0] == crvAddress
     assert token_prices[1][1] > 0


### PR DESCRIPTION
Quick update to the PricesHelper contract to pull the oracle address from yearn addresses provider instead of instantiating the contract with a fixed oracle address.  Now when the oracle deployment is updated, prices helper will point to current oracle address.

Additional changes:  Previous test for normalized values included usdc, however, stable coins can drop below or above $1 slightly.  When usdc drops to say 0.9999 this will cause the test to fail.  The test now uses yfi.