### PR TITLE
fix: fixes two issues with ITOA method of Strings library

### DIFF
--- a/contracts/Libraries/String.sol
+++ b/contracts/Libraries/String.sol
@@ -157,7 +157,13 @@ library String {
             buf[length - 1 - idx] ^= buf[idx];
             buf[idx] ^= buf[length - 1 - idx];
         }
+        if (length % 2 != 0 && input % base == 0) {
+            buf[length++] = "0"; // Append '0' if the length is odd and ends with a zero
+        }
         output = string(buf);
+        assembly {
+            mstore(output, length)
+        }
     }
 
     /**


### PR DESCRIPTION
    - When output string length is odd and ends with a zero, the zero is prepended to the string instead of appended
    - The length of the string is currently incorrectly set (length of bytes buffer is used instead of length of string)